### PR TITLE
Fixed evaluation SQL

### DIFF
--- a/src/services/modelTypes.ts
+++ b/src/services/modelTypes.ts
@@ -293,12 +293,8 @@ export const formConfusionMatrixSql = ({
     \`${gcpProject}\`.${bqmlModelDatasetName}.${bqModelName}${TABLE_SUFFIXES.confusionMatrix} AS (
     SELECT *
     FROM ML.CONFUSION_MATRIX (
-      MODEL \`${gcpProject}\`.${bqmlModelDatasetName}.${bqModelName},
-      (SELECT ${selectedFeatures.join(', ')}
-      FROM \`${gcpProject}\`.${bqmlModelDatasetName}.${bqModelName}${TABLE_SUFFIXES.inputData}_${uid})
-      ${threshold ?
-      `, STRUCT(${threshold} as threshold)` : ''
-    }
+      MODEL \`${gcpProject}\`.${bqmlModelDatasetName}.${bqModelName}
+      ${threshold ? `, STRUCT(${threshold} as threshold)` : '' } 
     ))
   `
 }
@@ -328,12 +324,8 @@ export const formROCCurveSql = ({
   }
   return `CREATE OR REPLACE VIEW
     \`${gcpProject}\`.${bqmlModelDatasetName}.${bqModelName}${TABLE_SUFFIXES.rocCurve} AS (
-    SELECT *
-    FROM ML.ROC_CURVE(
-      MODEL \`${gcpProject}\`.${bqmlModelDatasetName}.${bqModelName},
-      (SELECT ${selectedFeatures.join(', ')}
-      FROM \`${gcpProject}\`.${bqmlModelDatasetName}.${bqModelName}${TABLE_SUFFIXES.inputData}_${uid})
-    ))
+    SELECT * FROM ML.ROC_CURVE(MODEL \`${gcpProject}\`.${bqmlModelDatasetName}.${bqModelName})
+    )
   `
 }
 


### PR DESCRIPTION
Removed the optional 'table statement' parameters from both the [`ROC_CURVE`](https://cloud.google.com/bigquery-ml/docs/reference/standard-sql/bigqueryml-syntax-roc#roc_query_statement) and [`CONFUSION_MATRIX`](https://cloud.google.com/bigquery-ml/docs/reference/standard-sql/bigqueryml-syntax-confusion#eval_query_statement) functions called during the evaluate process.