### PR TITLE
Added a tickbox to enable Vertex AI model registry

### DIFF
--- a/src/components/Step3/AdvancedSettings/BoostedSettingsDialog.tsx
+++ b/src/components/Step3/AdvancedSettings/BoostedSettingsDialog.tsx
@@ -294,6 +294,15 @@ export const BoostedSettingsDialog: React.FC<BoostedSettingsDialogProps> = ({ cl
                   />
                 </div>
               </div>
+              <div className="form-row">
+                <TooltipLabel setting='modelRegistry'/>
+                <div className="settings-form-checkbox">
+                  <Checkbox
+                    checked={form.model_registry}
+                    onChange={() => handleCheckboxChange('model_registry')}
+                  />
+                </div>
+              </div>
             </div>
           </form>
         </div>

--- a/src/services/advancedSettings.ts
+++ b/src/services/advancedSettings.ts
@@ -35,6 +35,10 @@ export const advancedSettingsSql = (advancedSettings: any) => {
     sql = sql + ", ENABLE_GLOBAL_EXPLAIN = true"
   }
 
+  if (!advancedSettings || !Object.getOwnPropertyNames(advancedSettings).includes('model_registry')) {
+    sql = sql + ", MODEL_REGISTRY = {'VERTEX_AI'}" 
+  }
+
   return sql
 }
 
@@ -159,6 +163,10 @@ export const DATA_SPLIT_METHOD = ['AUTO_SPLIT', 'RANDOM', 'CUSTOM', 'SEQ', 'NO_S
 //   type: unquoted
 //   default_value: "FALSE" # { TRUE | FALSE }
 // }
+// parameter: model_registry {
+//   type: quoted
+//   default_value: "" # vertex_ai  
+// }
 
 const BOOSTED_CLASSIFIER_SETTINGS_DEFAULTS = {
   booster_type: 'GBTREE',
@@ -183,7 +191,8 @@ const BOOSTED_CLASSIFIER_SETTINGS_DEFAULTS = {
   data_split_method: 'AUTO_SPLIT',
   data_split_eval_fraction: 0.2,
   data_split_col: undefined,
-  enable_global_explain: true
+  enable_global_explain: true,
+  model_registry: false
 }
 
 const BOOSTED_REGRESSOR_SETTINGS_DEFAULTS = {
@@ -207,7 +216,8 @@ const BOOSTED_REGRESSOR_SETTINGS_DEFAULTS = {
   data_split_method: 'AUTO_SPLIT',
   data_split_eval_fraction: 0.2,
   data_split_col: undefined,
-  enable_global_explain: true
+  enable_global_explain: true,
+  model_registry: false
 }
 
 export const getBoostedSettingsDefaults = (objective: string) => {
@@ -389,5 +399,9 @@ export const SettingsLabelsAndTooltips: tooltipMapping = {
   enableGlobalExplain: {
     label: "Enable global explain", 
     tooltip: "Whether to compute global explanations using explainable AI to evaluate global feature importance to the model."
+  },
+  modelRegistry: {
+    label: "Vertex AI model registry",
+    tooltip: "Use Vertex AI model registry"
   }
 }

--- a/src/services/modelTypes.ts
+++ b/src/services/modelTypes.ts
@@ -184,7 +184,11 @@ const formBoostedTreeSQL = ({
   boostedType,
   advancedSettings
 }: IFormBoostedTreeModelCreateSQLProps): string => {
-  const settingsSql = advancedSettingsSql(advancedSettings)
+  let settingsSql = advancedSettingsSql(advancedSettings)
+  if (settingsSql.includes('MODEL_REGISTRY')) {
+    // Model name is unavailable in advancedSettings context so when using Vertex AI model registry we have to set the model ID here instead
+    settingsSql = settingsSql + ", VERTEX_AI_MODEL_ID = '" + bqmlModelDatasetName + "." + bqModelName + "'"
+  }
   return `
     CREATE OR REPLACE MODEL ${bqmlModelDatasetName}.${bqModelName}
           OPTIONS(MODEL_TYPE='BOOSTED_TREE_${boostedType.toUpperCase()}'


### PR DESCRIPTION
A "Use Vertex AI model registry" checkbox now appears at the bottom of the advanced settings dialog.

I took a crack at modifying the CREATE MODEL statement appropriately when checked (per https://cloud.google.com/bigquery-ml/docs/create_vertex#create_model_syntax), but my development environment isn't functioning properly and I couldn't test all the way through.

I kept getting the message "Failed to fetch summary. Please try again." when trying to proceed to Step 4. Creating PR anyways because I think the root of the issue is developing locally (pointing my manifest file to a localhost URL rather than bundle.js). This may just work, if not, I think it's close enough that Tom can take it from here.